### PR TITLE
Fixed small typo

### DIFF
--- a/Chapters/Objectives.md
+++ b/Chapters/Objectives.md
@@ -73,7 +73,7 @@ Metacello new
     load
 ```
 
-After you have loaded the MemoryTutorial project, you will get two new packages: `Bloc-Memory` and `Bloc-MemoryGame-Tests`. `Bloc-Memory-Tests` contains the full implementation of the game. 
+After you have loaded the MemoryTutorial project, you will get two new packages: `Bloc-Memory` and `Bloc-MemoryGame-Tests`. `Bloc-Memory` contains the full implementation of the game. 
 
 You can browse a model of the game just executing the following code snippet:
 


### PR DESCRIPTION
It fixes a small typo. In page 5 of the book, it says Bloc-Memory-Test contains the full implementation of the game. It is actually *Bloc-Memory* that contains the implementation, not the tests.